### PR TITLE
Enable mobile navigation bar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,8 +10,3 @@ search_enabled:   false
 
 permalink:        /posts/:title
 markdown: kramdown
-
-defaults:
-  - values:
-      layout: "default"
-


### PR DESCRIPTION
Site is currently unusable from mobile devices.

Removes explicit default layout from _config.yml

Jekyll will apply it automatically to actual pages, and this stops it from being applied to js files (which is really bad!)

Compare:

https://alchzh.github.io/pacensc/assets/js/just-the-docs.js  
https://pacensc.github.io/assets/js/just-the-docs.js